### PR TITLE
Improve `~course` command

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+    "tabWidth": 4,
+    "useTabs": false
+}

--- a/commands/course.js
+++ b/commands/course.js
@@ -3,6 +3,7 @@ const { request, gql } = require("graphql-request");
 const { uwflowQuery, uwflowEndpoint } = require("../util/uwflow-constants");
 
 const courseMatcher = /([a-zA-Z]{2,}[ ]?\d+[a-zA-Z]?)/g;
+const disallowedMatches = /(least)/gi;
 
 module.exports = {
     name: "course",
@@ -32,6 +33,9 @@ module.exports = {
         }
 
         const replacer = (course) => {
+            if (disallowedMatches.test(course)) {
+                return course;
+            }
             return `**[${course}](https://uwflow.com/course/${course
                 .toLowerCase()
                 .replace(/\s/g, "")})**`;

--- a/commands/course.js
+++ b/commands/course.js
@@ -13,7 +13,7 @@ module.exports = {
     displayHelp: true,
     usage: "(course)",
     async execute(message, args) {
-        const courseName = args.toLowerCase().replaceAll(/[^a-z0-9]/g, "");
+        const courseName = args.toLowerCase().replace(/[^a-z0-9]/g, "");
         const variables = {
             code: courseName,
             user_id: 0,
@@ -34,13 +34,13 @@ module.exports = {
         const replacer = (course) => {
             return `**[${course}](https://uwflow.com/course/${course
                 .toLowerCase()
-                .replaceAll(" ", "")})**`;
+                .replace(/\s/g, "")})**`;
         };
         const course = json.course[0];
         const prereqs =
-            course.prereqs?.replaceAll(courseMatcher, replacer) ?? "None";
+            course.prereqs?.replace(courseMatcher, replacer) ?? "None";
         const antireqs =
-            course.antireqs?.replaceAll(courseMatcher, replacer) ?? "None";
+            course.antireqs?.replace(courseMatcher, replacer) ?? "None";
 
         const responseEmbed = new Discord.MessageEmbed()
             .setColor("#9932cc")

--- a/commands/course.js
+++ b/commands/course.js
@@ -1,41 +1,69 @@
-const Discord = require('discord.js');
-const fetch = require('node-fetch');
+const Discord = require("discord.js");
+const { request, gql } = require("graphql-request");
+const { uwflowQuery, uwflowEndpoint } = require("../util/uwflow-constants");
+
+const courseMatcher = /([a-zA-Z]{2,}[ ]?\d+[a-zA-Z]?)/g;
 
 module.exports = {
-    name: 'course',
-    description: 'Get information about a UWaterloo course',
-    aliases: ['class'],
+    name: "course",
+    description: "Get information about a UWaterloo course",
+    aliases: ["class"],
     args: true,
     guildOnly: false,
     displayHelp: true,
     usage: "(course)",
     async execute(message, args) {
-        const courseName = args.toLowerCase().replace(/[^a-z0-9]/g, "")
-        const response = await fetch('https://uwflow.com/graphql', {
-            method: 'POST',
-            body: `{"operationName":"getCourse","variables":{"code":"${courseName}","user_id":0},"query":"query getCourse($code: String, $user_id: Int) {\n  course(where: {code: {_eq: $code}}) {\n    ...CourseInfo\n    ...CourseSchedule\n    ...CourseRequirements\n    ...CourseRating\n    __typename\n  }\n}\n\nfragment CourseInfo on course {\n  id\n  code\n  name\n  description\n  profs_teaching {\n    prof {\n      id\n      code\n      name\n      rating {\n        liked\n        comment_count\n        __typename\n      }\n      __typename\n    }\n    __typename\n  }\n  __typename\n}\n\nfragment CourseSchedule on course {\n  id\n  sections {\n    id\n    enrollment_capacity\n    enrollment_total\n    class_number\n    campus\n    section_name\n    term_id\n    updated_at\n    meetings {\n      days\n      start_date\n      end_date\n      start_seconds\n      end_seconds\n      location\n      prof {\n        id\n        code\n        name\n        __typename\n      }\n      is_closed\n      is_cancelled\n      is_tba\n      __typename\n    }\n    exams {\n      date\n      day\n      end_seconds\n      is_tba\n      location\n      section_id\n      start_seconds\n      __typename\n    }\n    __typename\n  }\n  __typename\n}\n\nfragment CourseRequirements on course {\n  id\n  antireqs\n  prereqs\n  coreqs\n  postrequisites {\n    postrequisite {\n      id\n      code\n      name\n      __typename\n    }\n    __typename\n  }\n  __typename\n}\n\nfragment CourseRating on course {\n  id\n  rating {\n    liked\n    easy\n    useful\n    filled_count\n    comment_count\n    __typename\n  }\n  __typename\n}\n"}`
-        });
-        const json = await response.json();
-        if (Object.keys(json.data.course).length < 1) {
-            message.channel.send(new Discord.MessageEmbed().setColor("#9932cc")
-                .setTitle('Error: No Course Found')
-                .setDescription(`No course with the name '${courseName}' was found.`))
+        const courseName = args.toLowerCase().replace(/[^a-z0-9]/g, "");
+        const variables = {
+            code: courseName,
+            user_id: 0,
+        };
+        const json = await request(uwflowEndpoint, uwflowQuery);
+        if (json.course.length < 1) {
+            message.channel.send(
+                new Discord.MessageEmbed()
+                    .setColor("#9932cc")
+                    .setTitle("Error: No Course Found")
+                    .setDescription(
+                        `No course with the name '${courseName}' was found.`
+                    )
+            );
             return;
         }
-        const course = json.data.course[0];
-        
+        const course = json.course[0];
+
         const responseEmbed = new Discord.MessageEmbed()
             .setColor("#9932cc")
             .setTitle(`${course.code.toUpperCase()}: ${course.name}`)
-            .setDescription(`${course.description}\n **[View course on UWFlow](https://uwflow.com/course/${courseName})**`)
-            .addFields(
-                { name: 'Prerequisites', value: (course.prereqs) ? course.prereqs : 'None'},
-                { name: 'Antirequisites', value: (course.antireqs) ? course.antireqs : 'None'},
-                { name: 'Liked', value: `${(course.rating.liked * 100).toFixed(2)}%`, inline: true },
-                { name: 'Easy', value: `${(course.rating.easy * 100).toFixed(2)}%`, inline: true },
-                { name: 'Useful', value: `${(course.rating.useful * 100).toFixed(2)}%`, inline: true },
+            .setDescription(
+                `${course.description}\n **[View course on UWFlow](https://uwflow.com/course/${courseName})**`
             )
-            .setFooter('https://github.com/sunny-zuo/sir-goose-bot');
+            .addFields(
+                {
+                    name: "Prerequisites",
+                    value: course.prereqs ? course.prereqs : "None",
+                },
+                {
+                    name: "Antirequisites",
+                    value: course.antireqs ? course.antireqs : "None",
+                },
+                {
+                    name: "Liked",
+                    value: `${(course.rating.liked * 100).toFixed(2)}%`,
+                    inline: true,
+                },
+                {
+                    name: "Easy",
+                    value: `${(course.rating.easy * 100).toFixed(2)}%`,
+                    inline: true,
+                },
+                {
+                    name: "Useful",
+                    value: `${(course.rating.useful * 100).toFixed(2)}%`,
+                    inline: true,
+                }
+            )
+            .setFooter("https://github.com/sunny-zuo/sir-goose-bot");
         message.channel.send(responseEmbed);
-    }
-}
+    },
+};

--- a/commands/course.js
+++ b/commands/course.js
@@ -13,12 +13,12 @@ module.exports = {
     displayHelp: true,
     usage: "(course)",
     async execute(message, args) {
-        const courseName = args.toLowerCase().replace(/[^a-z0-9]/g, "");
+        const courseName = args.toLowerCase().replaceAll(/[^a-z0-9]/g, "");
         const variables = {
             code: courseName,
             user_id: 0,
         };
-        const json = await request(uwflowEndpoint, uwflowQuery);
+        const json = await request(uwflowEndpoint, uwflowQuery, variables);
         if (json.course.length < 1) {
             message.channel.send(
                 new Discord.MessageEmbed()
@@ -30,7 +30,17 @@ module.exports = {
             );
             return;
         }
+
+        const replacer = (course) => {
+            return `**[${course}](https://uwflow.com/course/${course
+                .toLowerCase()
+                .replaceAll(" ", "")})**`;
+        };
         const course = json.course[0];
+        const prereqs =
+            course.prereqs?.replaceAll(courseMatcher, replacer) ?? "None";
+        const antireqs =
+            course.antireqs?.replaceAll(courseMatcher, replacer) ?? "None";
 
         const responseEmbed = new Discord.MessageEmbed()
             .setColor("#9932cc")
@@ -41,11 +51,11 @@ module.exports = {
             .addFields(
                 {
                     name: "Prerequisites",
-                    value: course.prereqs ? course.prereqs : "None",
+                    value: prereqs,
                 },
                 {
                     name: "Antirequisites",
-                    value: course.antireqs ? course.antireqs : "None",
+                    value: antireqs,
                 },
                 {
                     name: "Liked",

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,14 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cross-fetch": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
+      "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
+      "requires": {
+        "node-fetch": "2.6.1"
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -93,6 +101,36 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
+    "extract-files": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-9.0.0.tgz",
+      "integrity": "sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ=="
+    },
+    "form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      }
+    },
+    "graphql": {
+      "version": "15.5.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.0.tgz",
+      "integrity": "sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA=="
+    },
+    "graphql-request": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-3.4.0.tgz",
+      "integrity": "sha512-acrTzidSlwAj8wBNO7Q/UQHS8T+z5qRGquCQRv9J1InwR01BBWV9ObnoE+JS5nCCEj8wSGS0yrDXVDoRiKZuOg==",
+      "requires": {
+        "cross-fetch": "^3.0.6",
+        "extract-files": "^9.0.0",
+        "form-data": "^3.0.0"
+      }
     },
     "inherits": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
   "dependencies": {
     "discord.js": "^12.3.1",
     "dotenv": "^8.2.0",
+    "graphql": "^15.5.0",
+    "graphql-request": "^3.4.0",
     "luxon": "^1.25.0",
     "mongodb": "^3.6.0",
     "node-fetch": "^2.6.1",

--- a/util/uwflow-constants.js
+++ b/util/uwflow-constants.js
@@ -1,0 +1,111 @@
+const { gql } = require("graphql-request");
+
+const uwflowQuery = gql`
+    query getCourse($code: String, $user_id: Int) {
+        course(where: { code: { _eq: $code } }) {
+            ...CourseInfo
+            ...CourseSchedule
+            ...CourseRequirements
+            ...CourseRating
+            __typename
+        }
+    }
+    fragment CourseInfo on course {
+        id
+        code
+        name
+        description
+        profs_teaching {
+            prof {
+                id
+                code
+                name
+                rating {
+                    liked
+                    comment_count
+                    __typename
+                }
+                __typename
+            }
+            __typename
+        }
+        __typename
+    }
+    fragment CourseSchedule on course {
+        id
+        sections {
+            id
+            enrollment_capacity
+            enrollment_total
+            class_number
+            campus
+            section_name
+            term_id
+            updated_at
+            meetings {
+                days
+                start_date
+                end_date
+                start_seconds
+                end_seconds
+                location
+                prof {
+                    id
+                    code
+                    name
+                    __typename
+                }
+                is_closed
+                is_cancelled
+                is_tba
+                __typename
+            }
+            exams {
+                date
+                day
+                end_seconds
+                is_tba
+                location
+                section_id
+                start_seconds
+                __typename
+            }
+            __typename
+        }
+        __typename
+    }
+    fragment CourseRequirements on course {
+        id
+        antireqs
+        prereqs
+        coreqs
+        postrequisites {
+            postrequisite {
+                id
+                code
+                name
+                __typename
+            }
+            __typename
+        }
+        __typename
+    }
+    fragment CourseRating on course {
+        id
+        rating {
+            liked
+            easy
+            useful
+            filled_count
+            comment_count
+            __typename
+        }
+        __typename
+    }
+`;
+const uwflowEndpoint = "https://uwflow.com/graphql";
+
+module.exports = {
+    uwflowEndpoint,
+    uwflowQuery,
+};


### PR DESCRIPTION
This PR: 
- adds a Prettier config file for more consistent formatting
- cleans up the way the GraphQL request is made by replacing `node-fetch` with `graphql-request`
- adds clickable course links to the prerequisites and antirequisites sections in the Discord embed