### PR TITLE
Addition of New Feature: Pin-by-reply

### DIFF
--- a/commands/config.js
+++ b/commands/config.js
@@ -7,7 +7,8 @@ const settingsInfo = {
     verificationProgram: 'The UW program to verify for, formatted the same way as shown on WatIAM. Example: `VPA/Software Engineering`',
     verifiedRole: 'The name of the role to assign if the user belongs to the specified verificationProgram',
     guestRole: 'The name of the role to assign if the user verifies as a UW student but is in a different program. Can be disabled by setting the autoGuest setting to false',
-    autoGuest: 'Set whether or not the bot should assign the specified guestRole to users who are in a different program. Either `true` or `false`'
+    autoGuest: 'Set whether or not the bot should assign the specified guestRole to users who are in a different program. Either `true` or `false`',
+    enablePins: 'Set whether or not users without the manage messages permissions should be allowed to pin messages using the pin command'
 }
 
 function buildSettingListEmbed(message) {

--- a/commands/pin.js
+++ b/commands/pin.js
@@ -1,0 +1,23 @@
+const Discord = require('discord.js');
+const settings = require('../settings.js');
+
+module.exports = {
+    name: 'pin',
+    description: 'pins the referenced message used when invoking this command',
+    args: false,
+    guildOnly: true,
+    displayHelp: true,
+    permissions: ['MANAGE_MESSAGES'],
+    execute(message) {
+        if (message.reference) {
+            var chnl = messages.channel;
+            var referencedMessageID = message.reference.messageID;
+            var referencedMessage;
+            await chnl.messages.fetch(referencedMessageID).then(mmm => referencedMessage = mmm).catch(console.error);
+            await referencedMessage.pin({ reason: 'goose bot pin command invoked' }).then(messages => {
+                Log.success(`Pin request success for ${referencedMessage.content}`);
+            }).catch(console.error)
+            return;
+        }
+    }
+}

--- a/commands/pin.js
+++ b/commands/pin.js
@@ -7,21 +7,25 @@ module.exports = {
     args: false,
     guildOnly: true,
     displayHelp: false,
-    permissions: ['MANAGE_MESSAGES'],
     async execute(message) {
-        var chnl = message.channel;
-        if (message.reference) {
-            var referencedMessageID = message.reference.messageID;
-            var referencedMessage;
-            await chnl.messages.fetch(referencedMessageID).then(foundMessage => referencedMessage = foundMessage).catch(console.error);
-            await referencedMessage.pin({ reason: 'goose bot pin command invoked' }).then(result => {
-                //console.log(`Pin request success for Message: ${referencedMessage.content}`);
-            }).catch(console.error)
-            return;
+        const guildSettings = settings.get(message.guild?.id);
+        if (guildSettings.enablePins) {
+            let chnl = message.channel;
+            if (message.reference) {
+                let referencedMessageID = message.reference.messageID;
+                let referencedMessage;
+                await chnl.messages.fetch(referencedMessageID).then(foundMessage => referencedMessage = foundMessage).catch(console.error);
+                await referencedMessage.pin({ reason: 'goose bot pin command invoked' }).then(result => {
+                    //console.log(`Pin request success for Message: ${referencedMessage.content}`);
+                }).catch(console.error)
+                return;
+            } else {
+                chnl.send("No referenced message for pinning! Use the reply feature to add a referenced message and try again.").then(sentMessage => {
+                    setTimeout(function () { sentMessage.delete(); }, 5000)
+                })
+            }
         } else {
-            chnl.send("No referenced message for pinning! Use the reply feature to add a referenced message and try again.").then(sentMessage => {
-                setTimeout(function () { sentMessage.delete(); }, 5000)
-            })
+            message.channel.send(`Pinning is not enabled on this server. If you have server moderation permissions, use \`${guildSettings.prefix}config enablePins true\` to enable it.`);
         }
     }
 }

--- a/commands/pin.js
+++ b/commands/pin.js
@@ -12,11 +12,10 @@ module.exports = {
         var chnl = message.channel;
         if (message.reference) {
             var referencedMessageID = message.reference.messageID;
-            console.log(referencedMessageID);
             var referencedMessage;
-             await chnl.messages.fetch(referencedMessageID).then(foundMessage => referencedMessage=foundMessage).catch(console.error);
-             await referencedMessage.pin({ reason: 'goose bot pin command invoked' }).then(result => {
-                Log.success(`Pin request success for Message: ${referencedMessage.content}`);
+            await chnl.messages.fetch(referencedMessageID).then(foundMessage => referencedMessage = foundMessage).catch(console.error);
+            await referencedMessage.pin({ reason: 'goose bot pin command invoked' }).then(result => {
+                //console.log(`Pin request success for Message: ${referencedMessage.content}`);
             }).catch(console.error)
             return;
         } else {

--- a/commands/pin.js
+++ b/commands/pin.js
@@ -8,18 +8,19 @@ module.exports = {
     guildOnly: true,
     displayHelp: false,
     permissions: ['MANAGE_MESSAGES'],
-    execute(message) {
-        var chnl = messages.channel;
+    async execute(message) {
+        var chnl = message.channel;
         if (message.reference) {
             var referencedMessageID = message.reference.messageID;
+            console.log(referencedMessageID);
             var referencedMessage;
-            await chnl.messages.fetch(referencedMessageID).then(mmm => referencedMessage = mmm).catch(console.error);
-            await referencedMessage.pin({ reason: 'goose bot pin command invoked' }).then(result => {
+             await chnl.messages.fetch(referencedMessageID).then(foundMessage => referencedMessage=foundMessage).catch(console.error);
+             await referencedMessage.pin({ reason: 'goose bot pin command invoked' }).then(result => {
                 Log.success(`Pin request success for Message: ${referencedMessage.content}`);
             }).catch(console.error)
             return;
         } else {
-            chnl.send("No referenced message for pinning! Use the reply function to add a referenced message and try again.").then(sentMessage => {
+            chnl.send("No referenced message for pinning! Use the reply feature to add a referenced message and try again.").then(sentMessage => {
                 setTimeout(function () { sentMessage.delete(); }, 5000)
             })
         }

--- a/commands/pin.js
+++ b/commands/pin.js
@@ -6,18 +6,22 @@ module.exports = {
     description: 'pins the referenced message used when invoking this command',
     args: false,
     guildOnly: true,
-    displayHelp: true,
+    displayHelp: false,
     permissions: ['MANAGE_MESSAGES'],
     execute(message) {
+        var chnl = messages.channel;
         if (message.reference) {
-            var chnl = messages.channel;
             var referencedMessageID = message.reference.messageID;
             var referencedMessage;
             await chnl.messages.fetch(referencedMessageID).then(mmm => referencedMessage = mmm).catch(console.error);
-            await referencedMessage.pin({ reason: 'goose bot pin command invoked' }).then(messages => {
-                Log.success(`Pin request success for ${referencedMessage.content}`);
+            await referencedMessage.pin({ reason: 'goose bot pin command invoked' }).then(result => {
+                Log.success(`Pin request success for Message: ${referencedMessage.content}`);
             }).catch(console.error)
             return;
+        } else {
+            chnl.send("No referenced message for pinning! Use the reply function to add a referenced message and try again.").then(sentMessage => {
+                setTimeout(function () { sentMessage.delete(); }, 5000)
+            })
         }
     }
 }

--- a/settings.js
+++ b/settings.js
@@ -8,7 +8,8 @@ const defaultSettings = {
     verificationProgram: "VPA/Software Engineering",
     verifiedRole: "SE",
     guestRole: "Non-SE",
-    autoGuest: true
+    autoGuest: true,
+    enablePins: false
 }
 
 const loadSettings = () => {
@@ -23,7 +24,7 @@ const loadSettings = () => {
 
 const get = (serverID) => {
     // return server data if exists, else default settings
-    return servers.get(serverID) || { ...defaultSettings, serverID: serverID };
+    return { ...defaultSettings, ...servers.get(serverID) } || { ...defaultSettings, serverID: serverID };
 }
 
 const set = async (serverID, settings) => {


### PR DESCRIPTION
As previously discussed with regards to making pinning messages more accessible to non-admin users
This PR adds:
- Feature to allow goose bot to pin any message with the pin function

Usage:
1. Use the reply feature in discord messages to select the referenced message (an error message displays for lack of reply msg)
2. Use command [prefix]pin directly with no more arguments
3. Bot will automatically pin the message the command 'replies' to, to the channel.

![image](https://user-images.githubusercontent.com/65838712/109878714-a140db00-7c42-11eb-9676-cfb000bee3dd.png)

