### PR TITLE
fix: bypass discord caching for identical link

### DIFF
--- a/commands/honk.js
+++ b/commands/honk.js
@@ -1,22 +1,25 @@
 const randomGoose = "https://source.unsplash.com/random?goose,geese";
 const Discord = require("discord.js");
+const fetch = require("node-fetch");
 
 module.exports = {
-    name: 'honk',
-    description: 'Honk!',
+    name: "honk",
+    description: "Honk!",
     args: false,
     guildOnly: false,
     displayHelp: true,
-    execute(message) {
+    async execute(message) {
         if (Math.random() < 0.4) {
+            const redirectedGoose = await fetch(randomGoose, {
+                redirect: "follow",
+            }).then((r) => r.url);
             const embed = new Discord.MessageEmbed()
                 .setColor("#c51837")
                 .setTitle("HONK HONK")
-                .setImage(randomGoose);
+                .setImage(redirectedGoose);
             message.channel.send(embed);
         } else {
-            message.channel.send('HONK');
+            message.channel.send("HONK");
         }
-        
-    }
-}
+    },
+};


### PR DESCRIPTION
This PR fixes the `~honk` command by fetching the redirected goose image before sending the URL in the embed. This should bypass Discord's image caching mechanism when identical links (`https://source.unsplash.com/random?goose,geese`) are sent, thus the geese should be _actually_ random now.

Note that the `fetch` call is only used to follow the redirect and doesn't consume the response stream, so there should be no memory or performance impact in the long run.