### PR TITLE
fix: strict false check for guild availability

### DIFF
--- a/src/events/commandInteractionCreateEventHandler.ts
+++ b/src/events/commandInteractionCreateEventHandler.ts
@@ -19,7 +19,7 @@ export class CommandInteractionCreateEventHandler implements EventHandler {
 
         if (!command || !command.enabled) return;
         if (!command.isSlashCommand) return;
-        if (interaction.guild && !interaction.guild.available) return;
+        if (interaction.guild && interaction.guild.available === false) return;
         if (command.isRateLimited(interaction.user.id)) {
             this.client.log.info(
                 `${interaction.user.tag} tried to use ${command.name} in ${interaction.guild?.name ?? 'DMs'} (${

--- a/src/events/contextMenuInteractionCreateEventHandler.ts
+++ b/src/events/contextMenuInteractionCreateEventHandler.ts
@@ -18,7 +18,7 @@ export class ContextMenuInteractionCreateEventHandler implements EventHandler {
 
         if (!command || !command.enabled) return;
         if (!command.isContextMenuCommand) return;
-        if (interaction.guild && !interaction.guild.available) return;
+        if (interaction.guild && interaction.guild.available === false) return;
         if (command.isRateLimited(interaction.user.id)) {
             this.client.log.info(
                 `${interaction.user.tag} tried to use ${command.name} in ${interaction.guild?.name ?? 'DMs'} (${

--- a/src/events/messageCreateEventHandler.ts
+++ b/src/events/messageCreateEventHandler.ts
@@ -31,7 +31,7 @@ export class MessageCreateEventHandler implements EventHandler {
         const command = client.chatCommands.get(commandName) || client.chatAliases.get(commandName);
         if (!command || !command.enabled) return;
         if (!command.isTextCommand) return;
-        if (message.guild && !message.guild.available) return;
+        if (message.guild && message.guild.available === false) return;
         if (command.isRateLimited(message.author.id)) {
             this.client.log.info(
                 `${message.author.tag} tried to use ${command.name} in ${message.guild?.name ?? 'DMs'} (${


### PR DESCRIPTION
A [bug in discord.js v13.2.0](https://github.com/discordjs/discord.js/pull/6769) sets guild.available to be undefined (which is falsey) when the bot joins a new guild. A strict false check will prevent the bot from incorrectly exiting when guild.available is undefined (implying the guild is available).